### PR TITLE
fix: install ts-cli command wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OpenGemini is a cloud-native distributed time series database, find more informa
 **IMPORTANT**: It's highly recommended installing a specific version of `ts-cli` available on the [releases page](https://github.com/opengemini/openGemini-cli/releases).
 
 ```bash
-go install github.com/opengemini/openGemini-cli/cmd/ts-cli@latest
+go install github.com/openGemini/openGemini-cli/cmd/ts-cli@latest
 ```
 
 ## Usage


### PR DESCRIPTION
```
go instll github.com/opengemini/openGemini-cli/cmd/ts-cli@latest
```
need change to 
```
go instll github.com/openGemini/openGemini-cli/cmd/ts-cli@latest

```