### PR TITLE
fix: invalid username password flag injected via command line

### DIFF
--- a/core/http_client.go
+++ b/core/http_client.go
@@ -127,6 +127,10 @@ func NewHttpClient(cfg *CommandLineConfig) (HttpClient, error) {
 		}
 	}
 
+	if cfg.Username != "" && cfg.Password != "" {
+		client.SetAuth(cfg.Username, cfg.Password)
+	}
+
 	client.HostPort = schema + "://" + cfg.Host + ":" + strconv.FormatInt(int64(cfg.Port), 10)
 
 	client.client.Transport = transport


### PR DESCRIPTION
Fixed an abnormal scenario where the `--username` and `--password` parameters were invalid when the user used the command line