### PR TITLE
chore: refactor data import code

### DIFF
--- a/cmd/subcmd/import_test.go
+++ b/cmd/subcmd/import_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subcmd
+
+import (
+	"testing"
+
+	"github.com/openGemini/openGemini-cli/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimestamp(t *testing.T) {
+	type testCase struct {
+		timestamp string
+		precision string
+		expect    int64
+	}
+
+	testCases := []testCase{
+		{"1234567890", "s", 1234567890000000000},
+		{"1234567890", "ms", 1234567890000000},
+		{"1234567890", "us", 1234567890000},
+		{"1234567890", "ns", 1234567890},
+		{"1234567890000000000", "", 1234567890000000000},
+	}
+
+	for _, tcase := range testCases {
+		t.Run(tcase.precision, func(t *testing.T) {
+			c := new(ImportCommand)
+			cfg := &ImportConfig{CommandLineConfig: new(core.CommandLineConfig)}
+			cfg.Precision = tcase.precision
+			c.cfg = cfg
+			c.cfg.configTimeMultiplier()
+			act := c.parseTimestamp2Int64(tcase.timestamp)
+			require.Equal(t, tcase.expect, act)
+		})
+	}
+}

--- a/cmd/ts-cli/cli.go
+++ b/cmd/ts-cli/cli.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	subcmd "github.com/openGemini/openGemini-cli/cmd/subcmd"
 	"github.com/openGemini/openGemini-cli/common"
 	"github.com/openGemini/openGemini-cli/core"
 )
@@ -77,19 +78,19 @@ func (m *Command) versionCommand() {
 }
 
 func (m *Command) importCommand() {
-	var config = ImportConfig{CommandLineConfig: new(core.CommandLineConfig)}
+	var config = subcmd.ImportConfig{CommandLineConfig: new(core.CommandLineConfig)}
 	cmd := &cobra.Command{
 		Use:     "import",
 		Short:   "import data to openGemini",
 		Long:    "import line protocol text file to openGemini",
-		Example: "ts-cli import --format csv --host localhost --port 8086 --path file.csv --precision=s --database db0 --m m0 -r autogen",
+		Example: "ts-cli import --format csv --host localhost --port 8086 --path file.csv --precision=s --database db0 -m m0 -r autogen",
 		CompletionOptions: cobra.CompletionOptions{
 			DisableNoDescFlag:   true,
 			DisableDescriptions: true,
 			HiddenDefaultCmd:    true,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			importCmd := new(ImportCommand)
+			importCmd := new(subcmd.ImportCommand)
 			return importCmd.Run(&config)
 		},
 	}
@@ -104,17 +105,17 @@ func (m *Command) importCommand() {
 	cmd.Flags().StringVarP(&config.Cert, "cert", "C", "", "client certificate file when connecting openGemini by https.")
 	cmd.Flags().StringVarP(&config.CertKey, "cert-key", "k", "", "client certificate password.")
 	cmd.Flags().BoolVarP(&config.InsecureHostname, "insecure-hostname", "I", false, "ignore server certificate hostname verification when connecting openGemini by https.")
-	cmd.Flags().BoolVarP(&config.ColumnWrite, "column-write", "w", false, "use high performance column writing protocol, default use line protocol")
-	cmd.Flags().IntVarP(&config.ColumnWritePort, "column-write-port", "W", common.DefaultColumnWritePort, "high performance column writing protocol service port")
-	cmd.Flags().IntVarP(&config.BatchSize, "batch-size", "b", common.DefaultBatchSize, "enable batch submission to improve write performance")
-	cmd.Flags().StringVarP(&config.Path, "path", "T", "", "import file path to store openGemini")
-	cmd.Flags().StringVarP(&config.Format, "format", "f", common.DefaultFormat, "import file format, support 'line_protocol', 'csv'")
-	cmd.Flags().StringSliceVarP(&config.Tags, "tags", "", nil, "measurement tags name")
-	cmd.Flags().StringSliceVarP(&config.Fields, "fields", "", nil, "measurement fields name, if not specified, the remaining columns will act as fields")
-	cmd.Flags().StringVarP(&config.Measurement, "measurement", "m", "", "measurement name")
-	cmd.Flags().StringVarP(&config.Database, "database", "d", "", "database name")
-	cmd.Flags().StringVarP(&config.TimeField, "time", "t", "time", "measurement timestamp name")
-	cmd.Flags().StringVarP(&config.RetentionPolicy, "retention-policy", "r", common.DefaultRetentionPolicy, "measurement retention policy")
+	cmd.Flags().BoolVarP(&config.ColumnWrite, "column-write", "w", false, "use high performance column writing protocol, default use line protocol.")
+	cmd.Flags().IntVarP(&config.ColumnWritePort, "column-write-port", "W", common.DefaultColumnWritePort, "high performance column writing protocol service port.")
+	cmd.Flags().IntVarP(&config.BatchSize, "batch-size", "b", common.DefaultBatchSize, "enable batch submission to improve write performance.")
+	cmd.Flags().StringVarP(&config.Path, "path", "T", "", "import file path to store openGemini.")
+	cmd.Flags().StringVarP(&config.Format, "format", "f", common.DefaultFormat, "import file format, support 'line_protocol', 'csv'.")
+	cmd.Flags().StringSliceVarP(&config.Tags, "tags", "", nil, "measurement tags name.")
+	cmd.Flags().StringSliceVarP(&config.Fields, "fields", "", nil, "measurement fields name, if not specified, the remaining columns will act as fields.")
+	cmd.Flags().StringVarP(&config.Measurement, "measurement", "m", "", "measurement name.")
+	cmd.Flags().StringVarP(&config.Database, "database", "d", "", "database name.")
+	cmd.Flags().StringVarP(&config.TimeField, "time", "t", "time", "measurement timestamp name.")
+	cmd.Flags().StringVarP(&config.RetentionPolicy, "retention-policy", "r", common.DefaultRetentionPolicy, "measurement retention policy.")
 	cmd.Flags().StringVarP(&config.Precision, "precision", "U", "ns", "precision for time unit conversion, support 's', 'ms', 'us', 'ns'.")
 
 	cmd.MarkFlagsRequiredTogether("username", "password")


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #23 

### What is changed and how it works?
本次，提交主要是对导入数据的代码进行了重构，重构的好处：
1.原实现将`ImportCommand`等配置直接放在`main`包中，导致其他包无法复用配置且会产生循环依赖。通过将配置结构迁移至独立的`subcmd`子包，实现了配置的跨包复用能力，同时彻底消除了循环依赖问题，使单元测试可以轻松模拟各种配置场景。
2.对重复代码进行了封装，包括：`func (c *ImportCommand) executeByPointBuffer(ctx context.Context) error`
和`func (c *ImportCommand) excuteByLPBuffer(ctx context.Context) error {`，总计去掉了100多行冗余的代码，提升了代码的可维护性和可读性。

#### 额外增加了一个解析时间戳的单测函数：
✅ TestParseTimestamp

#### 后续计划：
1.支持`json`文件导入。

# Checklist:

✅ My code follows the style guidelines of this project
✅ I have performed a self-review of my own code
✅ I have commented my code, particularly in hard-to-understand areas
❌ I have made corresponding changes to the documentation
✅ My changes generate no new warnings
✅ I have added tests that prove my fix is effective or that my feature works
✅ New and existing unit tests pass locally with my changes
✅ Any dependent changes have been merged and published in downstream modules
