### PR TITLE
feat: make ts-cli support import json data

### DIFF
--- a/cmd/subcmd/import_test.go
+++ b/cmd/subcmd/import_test.go
@@ -50,3 +50,42 @@ func TestParseTimestamp(t *testing.T) {
 		})
 	}
 }
+
+func TestParse2String(t *testing.T) {
+	type testCase struct {
+		fieldType int
+		precision string
+		inputAny  any
+		expect    string
+	}
+
+	testCases := []testCase{
+		{Type_Field, "", 55, "55"},
+		{Type_Field, "", 66.6, "66.6"},
+		{Type_Field, "", true, "true"},
+		{Type_Field, "", false, "false"},
+		{Type_Field, "", "royal", "\"royal\""},
+		{Type_Field, "", nil, "\"\""},
+
+		{Type_Timestamp, "", 1234567890, "1234567890"},
+		{Type_Timestamp, "", 1234567890.1, "1234567890.1"},
+		{Type_Timestamp, "s", "2010-07-01T18:48:00Z", "1278010080"},
+		{Type_Timestamp, "ns", "2010-07-01T18:48:00Z", "1278010080000000000"},
+		{Type_Timestamp, "ms", "2010-07-01T18:48:00Z", "1278010080000"},
+		{Type_Timestamp, "us", "2010-07-01T18:48:00Z", "1278010080000000"},
+		{Type_Timestamp, "", "2010-07-01T18:48:00ZZZ", ""},
+	}
+
+	for _, tcase := range testCases {
+		t.Run(tcase.precision, func(t *testing.T) {
+			c := new(ImportCommand)
+			cfg := &ImportConfig{CommandLineConfig: new(core.CommandLineConfig)}
+			cfg.Precision = tcase.precision
+			c.cfg = cfg
+			err := c.cfg.configTimeMultiplier()
+			require.NoError(t, err)
+			act := c.parse2String(tcase.inputAny, tcase.fieldType)
+			require.Equal(t, tcase.expect, act)
+		})
+	}
+}

--- a/cmd/subcmd/import_test.go
+++ b/cmd/subcmd/import_test.go
@@ -60,20 +60,20 @@ func TestParse2String(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{Type_Field, "", 55, "55"},
-		{Type_Field, "", 66.6, "66.6"},
-		{Type_Field, "", true, "true"},
-		{Type_Field, "", false, "false"},
-		{Type_Field, "", "royal", "\"royal\""},
-		{Type_Field, "", nil, "\"\""},
+		{TypeField, "", 55, "55"},
+		{TypeField, "", 66.6, "66.6"},
+		{TypeField, "", true, "true"},
+		{TypeField, "", false, "false"},
+		{TypeField, "", "royal", "\"royal\""},
+		{TypeField, "", nil, "\"\""},
 
-		{Type_Timestamp, "", 1234567890, "1234567890"},
-		{Type_Timestamp, "", 1234567890.1, "1234567890.1"},
-		{Type_Timestamp, "s", "2010-07-01T18:48:00Z", "1278010080"},
-		{Type_Timestamp, "ns", "2010-07-01T18:48:00Z", "1278010080000000000"},
-		{Type_Timestamp, "ms", "2010-07-01T18:48:00Z", "1278010080000"},
-		{Type_Timestamp, "us", "2010-07-01T18:48:00Z", "1278010080000000"},
-		{Type_Timestamp, "", "2010-07-01T18:48:00ZZZ", ""},
+		{TypeTimestamp, "", 1234567890, "1234567890"},
+		{TypeTimestamp, "", 1234567890.1, "1234567890.1"},
+		{TypeTimestamp, "s", "2010-07-01T18:48:00Z", "1278010080"},
+		{TypeTimestamp, "ns", "2010-07-01T18:48:00Z", "1278010080000000000"},
+		{TypeTimestamp, "ms", "2010-07-01T18:48:00Z", "1278010080000"},
+		{TypeTimestamp, "us", "2010-07-01T18:48:00Z", "1278010080000000"},
+		{TypeTimestamp, "", "2010-07-01T18:48:00ZZZ", ""},
 	}
 
 	for _, tcase := range testCases {

--- a/cmd/subcmd/json.go
+++ b/cmd/subcmd/json.go
@@ -1,0 +1,304 @@
+// Copyright 2025 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subcmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/openGemini/openGemini-cli/common"
+	"github.com/openGemini/opengemini-client-go/opengemini"
+)
+
+// prom json format
+type JsonPResult struct {
+	Metric map[string]string `json:"metric"`
+	Values [][2]any          `json:"values,omitempty"`
+	Value  [2]any            `json:"value,omitempty"`
+}
+
+func (fsm *ImportFileFSM) processJsonP(dec *json.Decoder) (FSMCall, error) {
+	var res JsonPResult
+	switch fsm.state {
+	case importStateDDL:
+		return func(ctx context.Context, command *ImportCommand) error {
+			t, err := dec.Token()
+			if err != nil {
+				slog.Error("parse prom json failed", "reason", err)
+				return err
+			}
+			if t == "result" {
+				_, err := dec.Token() // skip [
+				if err != nil {
+					slog.Error("parse prom json failed", "reason", err)
+					return err
+				}
+				fsm.state = importStateDML
+				command.cfg.ColumnWrite = false // only support row protocol
+				// setup fsm config
+				cmdStr := fmt.Sprintf("CREATE DATABASE %s", command.cfg.Database)
+				_, err = command.httpClient.Query(ctx, &opengemini.Query{
+					Command: cmdStr, // CREATE DATABASE xxx
+				})
+				if err != nil {
+					slog.Error("execute ddl failed", "reason", err, "command", cmdStr)
+					return err
+				}
+				slog.Info("execute ddl success", "command", cmdStr)
+				fsm.database = command.cfg.Database
+				fsm.retentionPolicy = command.cfg.RetentionPolicy
+				fsm.measurement = command.cfg.Measurement
+				fsm.tagMap = make(map[string]FieldPos)
+				fsm.fieldMap = make(map[string]FieldPos)
+				if len(command.cfg.Fields) == 0 {
+					command.cfg.Fields = []string{"value"}
+				}
+				for _, tag := range command.cfg.Tags { // tags
+					fsm.tagMap[tag] = FieldPos{}
+				}
+				for _, field := range command.cfg.Fields { // fields
+					fsm.fieldMap[field] = FieldPos{}
+					break // field only one column
+				}
+			}
+			return nil
+		}, nil
+	case importStateDML:
+		return func(ctx context.Context, command *ImportCommand) error {
+			if err := dec.Decode(&res); err != nil {
+				slog.Error("parse prom json failed", "reason", err)
+				return err
+			}
+			if command.fsm.database == "" {
+				return errors.New("database is required")
+			}
+			if command.fsm.retentionPolicy == "" {
+				command.fsm.retentionPolicy = common.DefaultRetentionPolicy // "autogen"
+			}
+			if command.cfg.Measurement == "" {
+				return errors.New("measurement is required")
+			}
+
+			// parse to datas "m,location=coyote_creek,randtag=2 index=15 1566123456"
+			var dataSlice []string
+			// if len(fsm.tagMap) > 0
+			line := command.fsm.measurement
+			if len(command.fsm.tagMap) > 0 {
+				for tag := range command.fsm.tagMap {
+					line += fmt.Sprintf(",%s=%s", tag, res.Metric[tag])
+				}
+			} else {
+				for tag, v := range res.Metric {
+					line += fmt.Sprintf(",%s=%s", tag, v)
+				}
+			}
+
+			if len(res.Values) > 0 {
+				for _, v := range res.Values {
+					// v[0] is float64, parse to string
+					dataSlice = append(dataSlice, fmt.Sprintf("%s %s=%s %s", line, command.cfg.Fields[0], v[1], strconv.FormatFloat(v[0].(float64), 'f', -1, 64)))
+				}
+			} else {
+				dataSlice = append(dataSlice, fmt.Sprintf("%s %s=%s %s", line, command.cfg.Fields[0], res.Value[1], strconv.FormatFloat(res.Value[0].(float64), 'f', -1, 64)))
+			}
+
+			command.fsm.batchLPBuffer = append(command.fsm.batchLPBuffer, dataSlice...)
+			if len(command.fsm.batchLPBuffer) < command.cfg.BatchSize {
+				return nil
+			}
+			return command.excuteByLPBuffer(ctx)
+
+		}, nil
+	}
+
+	return FSMCallEmpty, nil
+}
+
+// influx json format
+type JsonIResult struct {
+	Measurement string            `json:"name"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	Fields      []string          `json:"columns"`
+	Values      [][]any           `json:"values"`
+}
+
+func (fsm *ImportFileFSM) processJsonI(dec *json.Decoder) (FSMCall, error) {
+	var res JsonIResult
+	switch fsm.state {
+	case importStateDDL:
+		return func(ctx context.Context, command *ImportCommand) error {
+			t, err := dec.Token()
+			if err != nil {
+				slog.Error("parse influx json failed", "reason", err)
+				return err
+			}
+
+			if t == "series" {
+				_, err := dec.Token() // skip [
+				if err != nil {
+					slog.Error("parse influx json failed", "reason", err)
+					return err
+				}
+
+				fsm.state = importStateDML
+				command.cfg.ColumnWrite = false // only support row protocol
+				// update db, rp
+				fsm.database = command.cfg.Database
+				fsm.retentionPolicy = command.cfg.RetentionPolicy
+
+				// create db
+				cmdStr := fmt.Sprintf("CREATE DATABASE %s", command.cfg.Database)
+				if _, err = command.httpClient.Query(ctx, &opengemini.Query{
+					Command: cmdStr, // CREATE DATABASE xxx
+				}); err != nil {
+					slog.Error("execute ddl failed", "reason", err, "command", cmdStr)
+					return err
+				}
+				slog.Info("execute ddl success", "command", cmdStr)
+			}
+			return nil
+		}, nil
+	case importStateDML:
+		return func(ctx context.Context, command *ImportCommand) error {
+			if err := dec.Decode(&res); err != nil {
+				slog.Error("parse influx json failed", "reason", err)
+				return err
+			}
+			if command.fsm.database == "" {
+				return errors.New("database is required")
+			}
+			if command.fsm.retentionPolicy == "" {
+				command.fsm.retentionPolicy = common.DefaultRetentionPolicy // "autogen"
+			}
+
+			// parse to datas "m,location=coyote_creek,randtag=2 index=15 1566123456"
+			var dataSlice []string
+
+			// parse struct
+			line := res.Measurement
+			if len(res.Tags) != 0 {
+				for tag, val := range res.Tags {
+					line += fmt.Sprintf(",%s=%s", tag, val)
+				}
+			}
+			// reuse fsm config
+			command.fsm.clearFieldConfig()
+			for i, field := range res.Fields {
+				if field == "time" {
+					command.fsm.timeField = FieldPos{field, i}
+				} else {
+					command.fsm.fieldMap[field] = FieldPos{field, i}
+				}
+			}
+
+			// parse the value of fields
+			for _, value := range res.Values {
+				var fields string
+				var timestamp string
+				var tidx int = -1 // time column not exist
+				if command.fsm.timeField.Name != "" {
+					tidx = command.fsm.timeField.Pos
+				}
+				for _, field := range command.fsm.fieldMap {
+					if field.Pos < len(value) {
+						fk, fv := field.Name, value[field.Pos] // fields value (string, float64, int64, bool)  ->  string
+						fields += fmt.Sprintf("%s=%s,", fk, command.parse2String(fv, Type_Field))
+					}
+				}
+				if len(fields) > 0 {
+					fields = fields[:len(fields)-1]
+				}
+
+				if tidx != -1 && tidx < len(value) {
+					tsp := value[tidx] // 1234567890 or "2010-07-01T18:48:00Z" -> "1234567890"
+					timestamp = command.parse2String(tsp, Type_Timestamp)
+				}
+
+				if tidx == -1 || timestamp == "" {
+					dataSlice = append(dataSlice, fmt.Sprintf("%s %s", line, fields))
+				} else {
+					dataSlice = append(dataSlice, fmt.Sprintf("%s %s %s", line, fields, timestamp))
+				}
+
+			}
+
+			command.fsm.batchLPBuffer = append(command.fsm.batchLPBuffer, dataSlice...)
+			if len(command.fsm.batchLPBuffer) < command.cfg.BatchSize {
+				return nil
+			}
+			return command.excuteByLPBuffer(ctx)
+		}, nil
+	}
+
+	return FSMCallEmpty, nil
+}
+
+func (fsm *ImportFileFSM) clearFieldConfig() {
+	fsm.tagMap = make(map[string]FieldPos)
+	fsm.fieldMap = make(map[string]FieldPos)
+	fsm.timeField = FieldPos{}
+}
+
+const (
+	Type_Timestamp = iota
+	Type_Field
+)
+
+func (c *ImportCommand) parse2String(s any, t int) string {
+	if t == Type_Field { // field
+		switch s := s.(type) { // fields value (string, float64, int64, bool)  ->  string
+		case float64:
+			return strconv.FormatFloat(s, 'f', -1, 64)
+		case int64:
+			return strconv.FormatInt(s, 10)
+		case int32:
+			return strconv.FormatInt(int64(s), 10)
+		case int:
+			return strconv.FormatInt(int64(s), 10)
+		case bool:
+			if s {
+				return "true"
+			}
+			return "false"
+		case string:
+			return fmt.Sprintf("\"%s\"", s)
+		}
+		return "\"\""
+	} else if t == Type_Timestamp { // 1234567890 or "2010-07-01T18:48:00Z" -> "1234567890"
+		switch s := s.(type) {
+		case float64:
+			return strconv.FormatFloat(s, 'f', -1, 64)
+		case int64:
+			return strconv.FormatInt(s, 10)
+		case int32:
+			return strconv.FormatInt(int64(s), 10)
+		case int:
+			return strconv.FormatInt(int64(s), 10)
+		case string: // must parse "2010-07-01T18:48:00Z" ->  "1234567890"
+			if tt, err := time.Parse(time.RFC3339, s); err != nil {
+				return ""
+			} else {
+				tsp := tt.UnixNano() / c.cfg.TimeMultiplier
+				return strconv.FormatFloat(float64(tsp), 'f', -1, 64)
+			}
+		}
+	}
+	return ""
+}

--- a/cmd/subcmd/json.go
+++ b/cmd/subcmd/json.go
@@ -23,11 +23,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/openGemini/openGemini-cli/common"
 	"github.com/openGemini/opengemini-client-go/opengemini"
+
+	"github.com/openGemini/openGemini-cli/common"
 )
 
-// prom json format
+// JsonPResult prom json format
 type JsonPResult struct {
 	Metric map[string]string `json:"metric"`
 	Values [][2]any          `json:"values,omitempty"`
@@ -131,7 +132,7 @@ func (fsm *ImportFileFSM) processJsonP(dec *json.Decoder) (FSMCall, error) {
 	return FSMCallEmpty, nil
 }
 
-// influx json format
+// JsonIResult influx json format
 type JsonIResult struct {
 	Measurement string            `json:"name"`
 	Tags        map[string]string `json:"tags,omitempty"`
@@ -219,7 +220,7 @@ func (fsm *ImportFileFSM) processJsonI(dec *json.Decoder) (FSMCall, error) {
 				for _, field := range command.fsm.fieldMap {
 					if field.Pos < len(value) {
 						fk, fv := field.Name, value[field.Pos] // fields value (string, float64, int64, bool)  ->  string
-						fields += fmt.Sprintf("%s=%s,", fk, command.parse2String(fv, Type_Field))
+						fields += fmt.Sprintf("%s=%s,", fk, command.parse2String(fv, TypeField))
 					}
 				}
 				if len(fields) > 0 {
@@ -228,7 +229,7 @@ func (fsm *ImportFileFSM) processJsonI(dec *json.Decoder) (FSMCall, error) {
 
 				if tidx != -1 && tidx < len(value) {
 					tsp := value[tidx] // 1234567890 or "2010-07-01T18:48:00Z" -> "1234567890"
-					timestamp = command.parse2String(tsp, Type_Timestamp)
+					timestamp = command.parse2String(tsp, TypeTimestamp)
 				}
 
 				if tidx == -1 || timestamp == "" {
@@ -257,12 +258,12 @@ func (fsm *ImportFileFSM) clearFieldConfig() {
 }
 
 const (
-	Type_Timestamp = iota
-	Type_Field
+	TypeTimestamp = iota
+	TypeField
 )
 
 func (c *ImportCommand) parse2String(s any, t int) string {
-	if t == Type_Field { // field
+	if t == TypeField { // field
 		switch s := s.(type) { // fields value (string, float64, int64, bool)  ->  string
 		case float64:
 			return strconv.FormatFloat(s, 'f', -1, 64)
@@ -281,7 +282,7 @@ func (c *ImportCommand) parse2String(s any, t int) string {
 			return fmt.Sprintf("\"%s\"", s)
 		}
 		return "\"\""
-	} else if t == Type_Timestamp { // 1234567890 or "2010-07-01T18:48:00Z" -> "1234567890"
+	} else if t == TypeTimestamp { // 1234567890 or "2010-07-01T18:48:00Z" -> "1234567890"
 		switch s := s.(type) {
 		case float64:
 			return strconv.FormatFloat(s, 'f', -1, 64)

--- a/cmd/ts-cli/cli.go
+++ b/cmd/ts-cli/cli.go
@@ -110,7 +110,7 @@ func (m *Command) importCommand() {
 	cmd.Flags().IntVarP(&config.ColumnWritePort, "column-write-port", "W", common.DefaultColumnWritePort, "high performance column writing protocol service port.")
 	cmd.Flags().IntVarP(&config.BatchSize, "batch-size", "b", common.DefaultBatchSize, "enable batch submission to improve write performance.")
 	cmd.Flags().StringVarP(&config.Path, "path", "T", "", "import file path to store openGemini.")
-	cmd.Flags().StringVarP(&config.Format, "format", "f", common.DefaultFormat, "import file format, support 'line_protocol', 'csv'.")
+	cmd.Flags().StringVarP(&config.Format, "format", "f", common.DefaultFormat, "import file format, support 'line_protocol', 'csv', 'jsoni', 'jsonp'.")
 	cmd.Flags().StringSliceVarP(&config.Tags, "tags", "", nil, "measurement tags name.")
 	cmd.Flags().StringSliceVarP(&config.Fields, "fields", "", nil, "measurement fields name, if not specified, the remaining columns will act as fields.")
 	cmd.Flags().StringVarP(&config.Measurement, "measurement", "m", "", "measurement name.")


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: resolve #24

### What is changed and how it works?
目前新增加两种文件格式：`prom json`和`influx json`。
```shell
>ts-cli import -h
import line protocol text file to openGemini
Usage:
    ts-cli import [flags]
Examples:
ts-cli import --format csv --host localhost --port 8086 --path file.csv --precision=s --database db0 -m m0 -r autogen 

Flags:
-b, --batch-size int            enable batch submission to improve write performance (default 100)
-c, --cacert string             CA certificate to verify peer against when connecting openGemini by https.
-C, --cert string               client certificate file when connecting openGemini by https.
-k, --cert-key string           client certificate password.
-w, --column-write              use high performance column writing protocol, default use line protocol
-W, --column-write-port int     high performance column writing protocol service port (default 8305)
-d, --database string           database name
    --fields strings            measurement fields name
-f, --format line_protocol      import file format, support `line_protocol`, `csv`, `jsoni`, `josnp`.
-h, --help                      help for import
-H, --host string               ts-sql host to connect to. (default "localhost")
-I, --insecure-hostname         ignore server certificate hostname verification when connecting openGemini by https.
-i, --insecure-tls              ignore ssl verification when connecting openGemini by https.
-m, --measurement string        measurement name
-P, --password string           password to connect to openGemini.
-T, --path string               import file path to store openGemini
-p, --port int                  ts-sql tcp port to connect to. (default 8086)
-U, --precision string          precision for time unit conversion. (default "ns")
-r, --retention-policy string   measurement retention policy (default "autogen")
-s, --ssl                       use https for connecting to openGemini.
    --tags strings              measurement tags name
-t, --time string               measurement timestamp name (default "time")
    --timeout int               request-timeout in mill-seconds. (default 5000)
-u, --username string           username to connect to openGemini.
```

如何导入`prom json`文件，prom.json模板内容如下：
模板1：
```json
{
	"status": "success",
	"data": {
		"resultType": "vector",
		"result": [{
			"metric": {
				"a": "down",
				"b": "localhost:8080",
				"c": "container"
			},
			"value": [1709258312, "2"]
		}, {
			"metric": {
				"a": "down",
				"b": "localhost:8086",
				"c": "prometheus"
			},
			"value": [1719258314, "2"]
		}]
	}
}

```
模板2：
```json
{
	"status": "success",
	"data": {
		"resultType": "matrix",
		"result": [{
			"metric": {
				"__name__": "up",
				"instance": "localhost:7070",
				"job": "container"
			},
			"values": [
				[1709258402, "123"]
			]
		}, {
			"metric": {
				"__name__": "up",
				"instance": "localhost:8080",
				"job": "container"
			},
			"values": [
				[1709258312, "1"],
				[1709258327, "2"],
				[1709258342, "3"],	
				[1709258357, "4"],
				[1709258372, "5"],
				[1709258387, "6"],
				[1709258402, "7"]
			]
		}, {
			"metric": {
				"__name__": "up",
				"instance": "localhost:8086",
				"job": "prometheus"
			},
			"values": [
				[1709258312, "1000"],
				[1709258327, "8"],
				[1709258342, "9"],
				[1709258357, "13"],
				[1709258372, "10"],
				[1709258387, "11"],
				[1709258402, "15"]
			]
		}]
	}
}
```

- prom.json导入命令举例：
```shell
# 必须指定数据库名，表名，以及时间戳精度
ts-cli import --format=jsonp --path=/path/to/prom.json --host=127.0.0.1 --port=8086 --database=db12 --measurement=m1 --precision=s
```

如何导入`influx json`文件，`influx.json`模板内容如下：
```json
﻿{
    "results":[{
        "statement_id":0,
        "series":[{
            "name":"cpu",
            "tags":{
                "host":"server01"
            },
            "columns":["time","value"],
            "values":[[1234567890,1]]
        },{
            "name":"test",
            "tags":{
                "host":"server03"
            },
            "columns":["time","mode"],
            "values":[
                ["2010-07-01T18:47:00Z",60],
                ["2010-07-01T18:47:30Z",60],
                ["2010-07-01T18:48:00Z",60]
            ]
          },{
            "name":"test3",
            "columns":["time","mode","check","name"],
            "values":[
                ["2010-07-01T18:47:00Z",60,false,"royal_111"],
                ["2010-07-01T18:47:30Z",50,true,"panghu"],
                ["2010-07-01T18:48:00Z",90,false,null],
	        ["2010-07-01T18:49:00Z",80,true,"tdroyal"]
            ]
          }]
    }]
}
```
- `influx.json`导入命令举例：
```shell
# 必须指定数据库，如果json中存在数字型时间戳（例如：1234567890，需要时间戳精度）
ts-cli import --format=jsoni --path=/path/to/influx.json --host=127.0.0.1 --port=8086 --database=db13 --precision=s
# 如果json中时间戳是清一色的UTC字符串，则不需要指定时间戳（指定也不影响）
ts-cli import --format=jsoni --path=/path/to/influx.json --host=127.0.0.1 --port=8086 --database=db13
```

#### 注意事项：
1.因为`influx json`中可能存在多个表，而列协议只支持同时写一个表，因此`json`文件禁掉了`--column-write`，只支持行协议。
2.两种`json`都不建议给`--keys`和`--fields`，因为数据中都有。
3.`prom json`中的"resultType"只支持`matrix`、`vector`。
4.`prom json`的时间戳只支持数字型（例：1234567890），value只支持字符串数字（例："55"），可以参考给出的json数据。
5.支持`--batch-size=100`批量写入，不指定，默认为100。
6.`influx json`中的时间戳的键必须指定为`time`，值只支持UTC字符串格式（例："2010-07-01T18:47:00Z"）和数字型（例：1234567890）。

#### 新增单测函数：
`TestParse2String`：将`field`和`time`统一转为字符串

# Checklist:

✅ My code follows the style guidelines of this project
✅ I have performed a self-review of my own code
✅ I have commented my code, particularly in hard-to-understand areas
❌ I have made corresponding changes to the documentation
✅ My changes generate no new warnings
✅ I have added tests that prove my fix is effective or that my feature works
✅ New and existing unit tests pass locally with my changes
✅ Any dependent changes have been merged and published in downstream modules
